### PR TITLE
Fix duplicate import in server

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -9,7 +9,6 @@ from app.routers.users    import router as users_router
 from app.routers.cameras  import router as cameras_router
 from app.routers.predict  import router as predict_router
 from app.routers.ws       import router as ws_router
-from app.routers.predict  import router as predict_router
 from app.lifespan         import lifespan
 from app.routers.logs import router as logs
 


### PR DESCRIPTION
## Summary
- remove duplicate import of `predict_router`

## Testing
- `pytest -q`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855776e7868832b887e435ac09d5827